### PR TITLE
Automates cloud-init for a SQL server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,4 @@
-# Model Project Structure
+# OutSystems Database Server Automation
 
-Template repository with my baseline project directory structure and
-a simple helper script for encrypting secrets.
-
-## Directories
-
-* `bin`: Useful scripts for working with the project. There's one
-  script common to all projects  to simplify encrypting and 
-  decryting project secrets. The `direnv` configuration in the
-  template `.envrc` file add this to `PATH` for ease of use.
-* `secrets`: Directory for storing project secrets. They should only
-  be added to git when encrypted. The `secrets` script allows for 
-  easy encrypt/decrypt using GPG.
-* `work`: For working files that should not be added the repo. Any
-  script in the project can depend on this directory being there 
-  for working storage.
-
-
+Automation to support preparing a Linux server to run SQL Server
+for an OutSystems database.

--- a/bin/generate-cloud-init
+++ b/bin/generate-cloud-init
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+domain=${1}
+
+echo "#cloud-config"
+ytt --ignore-unknown-comments -f ${PROJECT_DIR}/cloud-init --data-value domain=${domain} \
+  --data-value microsoft.pgp_key="$(curl --silent https://packages.microsoft.com/keys/microsoft.asc)" \
+  --data-value microsoft.mssql_list="$(curl --silent https://packages.microsoft.com/config/ubuntu/20.04/mssql-server-2019.list)" \
+  --data-value microsoft.prod_list="$(curl --silent https://packages.microsoft.com/config/ubuntu/20.04/prod.list)" \
+  --data-value-file ssh.authorized_keys.crdant="${HOME}/.ssh/id_ed25519.pub"

--- a/cloud-init/schema.yml
+++ b/cloud-init/schema.yml
@@ -1,0 +1,11 @@
+#@data/values-schema
+---
+domain: ""
+microsoft:
+  pgp_key: ""
+  mssql_list: ""
+  prod_list: ""
+ssh:
+  authorized_keys:
+    crdant: ""
+

--- a/cloud-init/user-data.yml
+++ b/cloud-init/user-data.yml
@@ -1,0 +1,64 @@
+#@ load("@ytt:data", "data")
+---
+#cloud-config
+
+# This is the user-data configuration file for cloud-init. By default this sets
+# up an initial user called "ubuntu" with password "ubuntu", which must be
+# changed at first login. However, many additional actions can be initiated on
+# first boot from this file. The cloud-init documentation has more details:
+#
+# https://cloudinit.readthedocs.io/
+#
+# Some additional examples are provided in comments below the default
+# configuration.
+
+fqdn: #@ "db.{}".format(data.values.domain)
+
+users:
+- name: crdant
+  gecos: "Chuck D'Antonio"
+  groups:
+  - users 
+  - adm 
+  - sudo
+  ssh_authorized_keys: #@ data.values.ssh.authorized_keys.crdant
+  sudo: "ALL=(ALL) NOPASSWD:ALL"
+  lock_passwd: true
+
+## Update apt database and upgrade packages on first boot
+package_update: true
+package_upgrade: true
+
+## 
+apt:
+  preserve_sources_list: true
+  sources:
+    microsoft:
+      source: #@ data.values.microsoft.mssql_list 
+      key: #@ data.values.microsoft.pgp_key
+    mssql:
+      source: #@ data.values.microsoft.prod_list 
+      key: #@ data.values.microsoft.pgp_key
+
+## Install additional packages on first boot
+packages:
+- ca-certificates
+- curl
+- zsh
+- direnv
+- neovim
+- mssql-server
+- mssql-tools
+- unixodbc-dev
+- msodbcsql17
+
+## write the systemd service file and coredns config
+## files
+write_files: 
+- path: /etc/profile.d/mssql-tools.sh
+  content: |
+    export PATH="$PATH:/opt/mssql-tools/bin"
+ 
+### Run arbitrary commands at rc.local like time
+runcmd:
+- [ chsh, -s, /usr/bin/zsh, crdant ]


### PR DESCRIPTION
TL;DR
-----

Generates a cloud-init for OS database with MSSQL

Details
-------

Creates a YAML tempplate (using `ytt`) to generate user data to
customize a Focal server for use as a SQL Server for OutSystems.
Includes a script `generate-cloud-init` that generates the user
data for encoding and setting as an OVF property.
