### PR TITLE
Fixes `.envrc` when params haven't been decrypted

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,6 +5,9 @@ export WORK_DIR=${PROJECT_DIR}/work
 PATH=${PROJECT_DIR}/bin:${PATH}
 
 export PARAMS_YAML=${SECRETS_DIR}/params.yml
-export GOOGLE_CREDENTIALS=${SECRETS_DIR}/$(yq e .gcp.service-account ${PARAMS_YAML}).json
+watch_file ${PARAMS_YAML}
+if [[ -f ${PARAMS_YAML} ]] ; then 
+  export GOOGLE_CREDENTIALS=${SECRETS_DIR}/$(yq e .gcp.service-account ${PARAMS_YAML}).json
+fi
 
 export TF_VAR_project_root=${PROJECT_DIR}


### PR DESCRIPTION
TL;DR
-----

Repairs a defect where `direnv` would error out if params.yml
did not exist

Details
-------

The value for `GOOGLE_CREDENTIALS` is set based on one of the
parameters in `params.yml`. This caused an error when either
`params.yml` had not been created or was still encrypted. This
change fixes that error.
